### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,25 @@
+# Documentation Index
+
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/ApplePayAPI.md
+- [](&)Documentation/ApplePayGuide.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/ComplianceAPI.md
+- [](&)Documentation/ComplianceGuide.md
+- [](&)Documentation/ConfigurationAPI.md
+- [](&)Documentation/FraudDetectionAPI.md
+- [](&)Documentation/FraudDetectionGuide.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/PaymentManagerAPI.md
+- [](&)Documentation/PayPalAPI.md
+- [](&)Documentation/PayPalGuide.md
+- [](&)Documentation/Security.md
+- [](&)Documentation/SecurityAPI.md
+- [](&)Documentation/SecurityGuide.md
+- [](&)Documentation/StripeAPI.md
+- [](&)Documentation/StripeGuide.md
+- [](&)Documentation/Testing.md
+- [](&)Documentation/Troubleshooting.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,11 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AdvancedExample.swift
+- ``Examples/AdvancedExamples/AdvancedPaymentExample.swift
+- ``Examples/ApplePayExamples/ApplePayExample.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicExamples/BasicPaymentExample.swift
+- ``Examples/PaymentExampleApp.swift
+- ``Examples/PayPalExamples/PayPalExample.swift
+- ``Examples/SecurityExamples/SecurityExample.swift
+- ``Examples/StripeExamples/StripeExample.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.